### PR TITLE
Add Theme Options Object

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -20,7 +20,7 @@ function runTheme(options, req, res) {
   try {
     var theme = require( path.join(root, themeDirectory) );
     var themePackageJson = fs.readFileSync(path.join(root, themeDirectory, 'package.json'), 'utf8');
-    var render = theme.render(options.resume);
+    var render = theme.render(options.resume, options.themeOptions);
   } catch(e) {
     var error = e;
     console.log(error);
@@ -54,10 +54,16 @@ function runTheme(options, req, res) {
 
 var getTheme = function(req, res) {
   var resumeObject = _.cloneDeep(resume);
+  var themeOptions;
 
   if (req.body && req.body.resume) {
     console.log('Use posted resume');
     resumeObject = req.body.resume;
+  }
+
+  if (req.body && req.body.themeOptions) {
+    console.log('Use posted theme options');
+    themeOptions = req.body.themeOptions;
   }
 
   var theme = 'jsonresume-theme-' + req.params.theme;
@@ -77,7 +83,8 @@ var getTheme = function(req, res) {
       console.log('Theme cached');
       runTheme({
         themeDirectory: directoryFolder,
-        resume: resumeObject
+        resume: resumeObject,
+        themeOptions: themeOptions
       }, req, res);
       return;
     } else {
@@ -104,7 +111,8 @@ var getTheme = function(req, res) {
           if (exists) {
             runTheme({
               themeDirectory: directoryFolder,
-              resume: resumeObject
+              resume: resumeObject,
+              themeOptions: themeOptions
             }, req, res);
             return;
           } else {
@@ -168,7 +176,8 @@ var getTheme = function(req, res) {
                       function(error, stdout, stderr) {
                         runTheme({
                           themeDirectory: directoryFolder,
-                          resume: resumeObject
+                          resume: resumeObject,
+                          themeOptions: themeOptions
                         }, req, res);
                         if (error !== null) {
                           console.log('exec error: ' + error);

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -54,7 +54,7 @@ function runTheme(options, req, res) {
 
 var getTheme = function(req, res) {
   var resumeObject = _.cloneDeep(resume);
-  var themeOptions;
+  var themeOptions = {};
 
   if (req.body && req.body.resume) {
     console.log('Use posted resume');


### PR DESCRIPTION
I made a small change to allow a theme options class to be posted to the theme manager. It in turns passes it along to the themes render function as a second parameter. I also plan on updating the client tool to support this.

```javascript
function render(resume, themeOptions) {
	var css = fs.readFileSync(__dirname + "/style.css", "utf-8");
	var template = fs.readFileSync(__dirname + "/resume.template", "utf-8");
	return Handlebars.compile(template)({
		css: css,
		resume: resume,
		themeOptions: themeOptions
	});
}
```

Fixes this issue https://github.com/jsonresume/theme-manager/issues/15