### PR TITLE
Converting theme name to lower case irrespective of theme case sensitivity in the URL

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -66,7 +66,7 @@ var getTheme = function(req, res) {
     themeOptions = req.body.themeOptions;
   }
 
-  var theme = 'jsonresume-theme-' + req.params.theme;
+  var theme = 'jsonresume-theme-' + req.params.theme.toLowerCase();
   var version = '0';
   var versionCheck = theme.split('@');
   if (versionCheck.length > 1) {


### PR DESCRIPTION
Fixing an issue that I mentioned in resume-cli - https://github.com/jsonresume/resume-cli/issues/87